### PR TITLE
Use lower case, cleanup and formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ out
 .pnp.*
 pnpm-lock.yaml
 dist/
+.idea

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Install SnFoundry
+# Install Starknet Foundry
 
-Sets up [SnFoundry] in your GitHub Actions workflow supporting caching out of the box.
+Sets up [Starknet Foundry] in your GitHub Actions workflow supporting caching out of the box.
 
 ## Example workflow
 
@@ -15,20 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: foundry-rs/setup-snfoundry@v1
-        with:
-          starnet-foundry-version: "0.6.0"
       - run: snforge
 ```
 
 ## Inputs
 
 - `starknet-foundry-version` - **Optional**. String:
-  - Stating an explicit SnFoundry version to use, for example `"0.6.0"`.
+  - Stating an explicit Starknet Foundry version to use, for example `"0.8.3"`.
 
 ## Outputs
 
 - `starknet-foundry-prefix` - A path to where Starknet Foundry has been extracted to. The `snforge`and `sncast` binaries will be located in the `bin`
   subdirectory (`${{ steps.setup-starknet-foundry.outputs.starknet-foundry-prefix }}/bin`).
-- `starknet-foundry-version` - Installed SnFoundry version (as reported by `snforge -V`).
+- `starknet-foundry-version` - Version of Starknet Foundry that was installed (as reported by `snforge -V`).
 
-[SnFoundry]: https://foundry-rs.github.io/starknet-foundry
+[Starknet Foundry]: https://foundry-rs.github.io/starknet-foundry

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,13 @@ branding:
   icon: activity
 inputs:
   starknet-foundry-version:
-    description: SnFoundry version to use
+    description: Starknet Foundry version to use
     required: false
 outputs:
   starknet-foundry-prefix:
-    description: The prefix of the installed SnFoundry
+    description: The prefix of installed Starknet Foundry
   starknet-foundry-version:
-    description: The version of the installed SnFoundry
+    description: The version of installed Starknet Foundry
 runs:
   using: "node18"
   main: "dist/setup/index.js"

--- a/lib/download.js
+++ b/lib/download.js
@@ -33,5 +33,7 @@ async function findStarknetFoundryDir(extractedPath) {
     }
   }
 
-  throw new Error(`could not find Starknet Foundry directory in ${extractedPath}`);
+  throw new Error(
+    `could not find Starknet Foundry directory in ${extractedPath}`,
+  );
 }

--- a/lib/download.js
+++ b/lib/download.js
@@ -5,26 +5,26 @@ import * as tc from "@actions/tool-cache";
 import { getOsTriplet } from "./platform";
 import { versionWithPrefix } from "./versions";
 
-export async function downloadSnFoundry(repo, version) {
+export async function downloadStarknetFoundry(repo, version) {
   const triplet = getOsTriplet();
   const tag = versionWithPrefix(version);
   const basename = `starknet-foundry-${tag}-${triplet}`;
   const extension = triplet.includes("-windows-") ? "zip" : "tar.gz";
   const url = `https://github.com/${repo}/releases/download/${tag}/${basename}.${extension}`;
 
-  core.info(`Downloading SnFoundry from ${url}`);
+  core.info(`Downloading Starknet Foundry from ${url}`);
   const pathToTarball = await tc.downloadTool(url);
 
   const extract = url.endsWith(".zip") ? tc.extractZip : tc.extractTar;
   const extractedPath = await extract(pathToTarball);
 
-  const pathToCli = await findSnFoundryDir(extractedPath);
+  const pathToCli = await findStarknetFoundryDir(extractedPath);
 
   core.debug(`Extracted to ${pathToCli}`);
   return pathToCli;
 }
 
-async function findSnFoundryDir(extractedPath) {
+async function findStarknetFoundryDir(extractedPath) {
   for (const dirent of await fs.readdir(extractedPath, {
     withFileTypes: true,
   })) {
@@ -33,5 +33,5 @@ async function findSnFoundryDir(extractedPath) {
     }
   }
 
-  throw new Error(`could not find SnFoundry directory in ${extractedPath}`);
+  throw new Error(`could not find Starknet Foundry directory in ${extractedPath}`);
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,5 @@
-import { getFullVersionFromSnFoundry, versionWithPrefix } from "./versions";
-import { downloadSnFoundry } from "./download";
+import { getFullVersionFromStarknetFoundry, versionWithPrefix } from "./versions";
+import { downloadStarknetFoundry } from "./download";
 import { getOsTriplet } from "./platform";
 import path from "path";
 import * as core from "@actions/core";
@@ -7,43 +7,43 @@ import * as tc from "@actions/tool-cache";
 
 export default async function main() {
   try {
-    const SnFoundryVersionInput = core.getInput("version");
+    const StarknetFoundryVersionInput = core.getInput("version");
 
-    const { repo: SnFoundryRepo, version: SnFoundryVersion } = {
+    const { repo: StarknetFoundryRepo, version: StarknetFoundryVersion } = {
       rep: "foundry-rs/starknet-foundry",
-      version: SnFoundryVersionInput,
+      version: StarknetFoundryVersionInput,
     };
 
     const triplet = getOsTriplet();
     await core.group(
-      `Setting up SnFoundry ${versionWithPrefix(SnFoundryVersion)}`,
+      `Setting up Starknet Foundry ${versionWithPrefix(StarknetFoundryVersion)}`,
       async () => {
-        let SnFoundryPrefix = tc.find(
+        let StarknetFoundryPrefix = tc.find(
           "starknet-foundry",
-          SnFoundryVersion,
+          StarknetFoundryVersion,
           triplet,
         );
-        if (!SnFoundryPrefix) {
-          const download = await downloadSnFoundry(
-            SnFoundryRepo,
-            SnFoundryVersion,
+        if (!StarknetFoundryPrefix) {
+          const download = await downloadStarknetFoundry(
+            StarknetFoundryRepo,
+            StarknetFoundryVersion,
           );
           snforgePrefix = await tc.cacheDir(
             download,
             "starknet-foundry",
-            SnFoundryVersion,
+            StarknetFoundryVersion,
             triplet,
           );
         }
 
-        core.setOutput("starknet-foundry-prefix", SnFoundryPrefix);
-        core.addPath(path.join(SnFoundryPrefix, "bin"));
+        core.setOutput("starknet-foundry-prefix", StarknetFoundryPrefix);
+        core.addPath(path.join(StarknetFoundryPrefix, "bin"));
       },
     );
 
     core.setOutput(
       "starknet-fundry-version",
-      await getFullVersionFromSnFoundry(),
+      await getFullVersionFromStarknetFoundry(),
     );
   } catch (err) {
     core.setFailed(err);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,7 @@
-import { getFullVersionFromStarknetFoundry, versionWithPrefix } from "./versions";
+import {
+  getFullVersionFromStarknetFoundry,
+  versionWithPrefix,
+} from "./versions";
 import { downloadStarknetFoundry } from "./download";
 import { getOsTriplet } from "./platform";
 import path from "path";
@@ -16,7 +19,9 @@ export default async function main() {
 
     const triplet = getOsTriplet();
     await core.group(
-      `Setting up Starknet Foundry ${versionWithPrefix(StarknetFoundryVersion)}`,
+      `Setting up Starknet Foundry ${versionWithPrefix(
+        StarknetFoundryVersion,
+      )}`,
       async () => {
         let StarknetFoundryPrefix = tc.find(
           "starknet-foundry",

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -1,9 +1,9 @@
-export async function getFullVersionFromSnFoundry() {
+export async function getFullVersionFromStarknetFoundry() {
   const { stdout } = await exec.getExecOutput(`snforge -V`);
   const match = stdout.match(/^snforge ([^ ]+)/);
   if (!match) {
     throw new Error(
-      `unable to determine SnFoundry version from 'snforge -V' output: ${stdout}`,
+      `unable to determine Starknet Foundry version from 'snforge -V' output: ${stdout}`,
     );
   }
   return match[1];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "build": "ncc build index.js -o dist/setup --source-map --license licenses.txt",
-    "lint": "npm run fmt:check",
     "fmt:check": "prettier -c .",
     "fmt": "prettier -w ."
   },


### PR DESCRIPTION
- Closes #2 
- Replaced all usages of `SnFoundry` with `Starknet Foundry` or `StarknetFoundry`.
- Formatting
- Removed `lint` script that was duplicating `fmt:check`.