### PR TITLE
Trigger checks every week

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ on:
       - main
   schedule:
     # At 16:00 on Wednesday
-    - cron: '0 16 * * 3'
+    - cron: "0 16 * * 3"
 
 jobs:
   lint:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # At 16:00 on Wednesday
+    - cron: '0 16 * * 3'
 
 jobs:
   lint:


### PR DESCRIPTION
Closes https://github.com/foundry-rs/starknet-foundry/issues/1039

Add schedule trigger to checks so they are run every week. This way we don't have to manually test this action for new releases since the checks will eventually run.

I did not implement triggering the checks explicitly by new Starknet Foundry releases because it would require setting a personal access token.