### PR TITLE
Add universal-sierra-compiler dependency

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           starknet-foundry-version: latest
 
+      - name: Verify universal-sierra-compiler installation
+        run: universal-sierra-compiler --version
+
       - name: Create new project
         run: snforge init myproject
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29930,6 +29930,7 @@ function getOsPlatform() {
 
 
 
+
 async function downloadStarknetFoundry(repo, version) {
   const triplet = getOsTriplet();
   const tag = versionWithPrefix(version);
@@ -29964,8 +29965,6 @@ async function findStarknetFoundryDir(extractedPath) {
 }
 
 async function downloadUniversalSierraCompiler() {
-  const exec = __nccwpck_require__(1514);
-
   const scriptUrl =
     "https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh";
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29963,6 +29963,15 @@ async function findStarknetFoundryDir(extractedPath) {
   );
 }
 
+async function downloadUniversalSierraCompiler() {
+  const { exec } = __nccwpck_require__(2081);
+
+  const command =
+    "curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh";
+
+  exec(command);
+}
+
 ;// CONCATENATED MODULE: ./lib/main.js
 
 
@@ -29995,6 +30004,7 @@ async function main() {
           triplet,
         );
         if (!StarknetFoundryPrefix) {
+          await downloadUniversalSierraCompiler();
           const download = await downloadStarknetFoundry(
             StarknetFoundryRepo,
             StarknetFoundryVersion,

--- a/dist/index.js
+++ b/dist/index.js
@@ -29969,7 +29969,17 @@ async function downloadUniversalSierraCompiler() {
   const command =
     "curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh";
 
-  exec(command);
+  exec(command, (error, stdout, stderr) => {
+    if (error) {
+      console.error(
+        `Error while installing \`universal-sierra-compiler\`: ${error.message}`,
+      );
+      console.error(`Stderr: ${stderr}`);
+      return;
+    }
+
+    console.log(`Successfully installed \`universal-sierra-compiler\``);
+  });
 }
 
 ;// CONCATENATED MODULE: ./lib/main.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -29964,22 +29964,20 @@ async function findStarknetFoundryDir(extractedPath) {
 }
 
 async function downloadUniversalSierraCompiler() {
-  const { exec } = __nccwpck_require__(2081);
+  const exec = __nccwpck_require__(1514);
 
-  const command =
-    "curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh";
+  const scriptUrl =
+    "https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh";
 
-  exec(command, (error, stdout, stderr) => {
-    if (error) {
-      console.error(
-        `Error while installing \`universal-sierra-compiler\`: ${error.message}`,
-      );
-      console.error(`Stderr: ${stderr}`);
-      return;
-    }
+  try {
+    const scriptPath = await tool_cache.downloadTool(scriptUrl);
 
-    console.log(`Successfully installed \`universal-sierra-compiler\``);
-  });
+    await exec.exec(`chmod +x ${scriptPath}`);
+
+    await exec.exec(scriptPath);
+  } catch (error) {
+    core.setFailed(error.message);
+  }
 }
 
 ;// CONCATENATED MODULE: ./lib/main.js

--- a/lib/download.js
+++ b/lib/download.js
@@ -2,6 +2,7 @@ import path from "path";
 import fs from "fs/promises";
 import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
+import * as exec from "@actions/exec";
 import { getOsTriplet } from "./platform";
 import { versionWithPrefix } from "./versions";
 
@@ -39,20 +40,16 @@ async function findStarknetFoundryDir(extractedPath) {
 }
 
 export async function downloadUniversalSierraCompiler() {
-  const { exec } = require("child_process");
+  const scriptUrl =
+    "https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh";
 
-  const command =
-    "curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh";
+  try {
+    const scriptPath = await tc.downloadTool(scriptUrl);
 
-  exec(command, (error, stdout, stderr) => {
-    if (error) {
-      console.error(
-        `Error while installing \`universal-sierra-compiler\`: ${error.message}`,
-      );
-      console.error(`Stderr: ${stderr}`);
-      return;
-    }
+    await exec.exec(`chmod +x ${scriptPath}`);
 
-    console.log(`Successfully installed \`universal-sierra-compiler\``);
-  });
+    await exec.exec(scriptPath);
+  } catch (error) {
+    core.setFailed(error.message);
+  }
 }

--- a/lib/download.js
+++ b/lib/download.js
@@ -37,3 +37,12 @@ async function findStarknetFoundryDir(extractedPath) {
     `could not find Starknet Foundry directory in ${extractedPath}`,
   );
 }
+
+export async function downloadUniversalSierraCompiler() {
+  const { exec } = require("child_process");
+
+  const command =
+    "curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh";
+
+  exec(command);
+}

--- a/lib/download.js
+++ b/lib/download.js
@@ -46,8 +46,10 @@ export async function downloadUniversalSierraCompiler() {
 
   exec(command, (error, stdout, stderr) => {
     if (error) {
-      console.error(`Error while installing \`universal-sierra-compiler\`: ${error.message}`);
-      console.error(`Stderr: ${stderr}`)
+      console.error(
+        `Error while installing \`universal-sierra-compiler\`: ${error.message}`,
+      );
+      console.error(`Stderr: ${stderr}`);
       return;
     }
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -44,5 +44,13 @@ export async function downloadUniversalSierraCompiler() {
   const command =
     "curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh";
 
-  exec(command);
+  exec(command, (error, stdout, stderr) => {
+    if (error) {
+      console.error(`Error while installing \`universal-sierra-compiler\`: ${error.message}`);
+      console.error(`Stderr: ${stderr}`)
+      return;
+    }
+
+    console.log(`Successfully installed \`universal-sierra-compiler\``);
+  });
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,10 @@ import {
   getFullVersionFromStarknetFoundry,
   versionWithPrefix,
 } from "./versions";
-import { downloadStarknetFoundry } from "./download";
+import {
+  downloadStarknetFoundry,
+  downloadUniversalSierraCompiler,
+} from "./download";
 import { getOsTriplet } from "./platform";
 import path from "path";
 import * as core from "@actions/core";
@@ -33,6 +36,7 @@ export default async function main() {
           triplet,
         );
         if (!StarknetFoundryPrefix) {
+          await downloadUniversalSierraCompiler();
           const download = await downloadStarknetFoundry(
             StarknetFoundryRepo,
             StarknetFoundryVersion,


### PR DESCRIPTION
This PR invokes usc installation [script](https://github.com/software-mansion/universal-sierra-compiler/blob/master/scripts/install.sh) because a new version of starknet-foundry will use it