### PR TITLE
Fix path bug + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: foundry-rs/setup-snfoundry@v3
+      - uses: actions/checkout@v4
+      - uses: foundry-rs/setup-snfoundry@v4
       - run: snforge
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -24,4 +24,4 @@ runs:
 
     - name: Set up Starknet Foundry
       shell: bash
-      run: node dist/index.js
+      run: node $GITHUB_ACTION_PATH/dist/index.js


### PR DESCRIPTION


Unfortunately, the current release is broken because it runs `node dist/index.js`. This worked in our tests since they were in the same directory as the `dist` folder. However, when this action runs as an actual GitHub Action, the path to `dist` is different.  

Adding the `GITHUB_ACTION_PATH` environment variable fixes this issue. I tested this PR in `cairo-coverage`, and it seems to work perfectly:  
[Run details](https://github.com/software-mansion/cairo-coverage/actions/runs/13145644653/job/36683050369?pr=131).