### PR TITLE
Fix determining version

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set Node.js 20.x
         uses: actions/setup-node@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test local action
         uses: ./
         with:
-          starknet-foundry-version: 0.44.0
+          starknet-foundry-version: latest
 
       - name: Verify universal-sierra-compiler installation
         run: universal-sierra-compiler --version

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,10 +26,7 @@ jobs:
         run: npm run fmt:check
 
   test-action:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x
@@ -28,7 +28,7 @@ jobs:
   test-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get scarb version
         id: extractScarbVersion
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Setup Scarb using `.tool-versions` file"
+      - name: "Setup Scarb
         uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: 2.9.4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,15 +43,17 @@ jobs:
         with:
           scarb-version: ${{ steps.extractScarbVersion.outputs.scarbVersion }}
 
-      - name: Test local action (with fixed version)
+      - name: Setup local action (with fixed version)
         uses: ./
         with:
           starknet-foundry-version: 0.44.0
 
-      - name: Check that snforge version is correct
-        run: snforge --version | grep "snforge 0.44.0"
+      - name: Verify snforge version
+        run: |
+          VERSION=$(snforge --version)
+          [[ "$VERSION" == "snforge 0.44.0" ]]
 
-      - name: Test local action (with latest version)
+      - name: Setup local action (with latest version)
         uses: ./
 
       - name: Verify universal-sierra-compiler installation

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup local action (with fixed version)
         uses: ./
         with:
-          starknet-foundry-version: 0.44.0
+          starknet-foundry-version: 0.43.0
 
       - name: Verify snforge version
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,8 +50,17 @@ jobs:
 
       - name: Verify snforge version
         run: |
+          EXPECTED="snforge 0.44.0"
           VERSION=$(snforge --version)
-          [[ "$VERSION" == "snforge 0.44.0" ]]
+
+          echo "Expected version: $EXPECTED"
+          echo "Actual version:   $VERSION"
+
+          if [[ "$VERSION" != "$EXPECTED" ]]; then
+            echo "Version mismatch"
+            exit 1
+          fi
+
 
       - name: Setup local action (with latest version)
         uses: ./

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           starknet-foundry-version: 0.44.0
 
+
       - name: Verify snforge version
         run: |
           EXPECTED="snforge 0.44.0"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,6 @@ on:
   schedule:
     # At 16:00 on Wednesday
     - cron: "0 16 * * 3"
-  workflow_dispatch:
 
 jobs:
   lint:
@@ -81,7 +80,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: "Setup Scarb
         uses: software-mansion/setup-scarb@v1
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           snfoundry_version=$(curl -s https://api.github.com/repos/foundry-rs/starknet-foundry/releases/latest | grep tarball_url | awk -F '/' '{print $8}' | tr -d '",')
-          version=$(curl -s https://raw.githubusercontent.com/foundry-rs/starknet-foundry/$snfoundry_version/.tool-versions | awk '{print $2}')
+          version=$(curl -s https://raw.githubusercontent.com/foundry-rs/starknet-foundry/$snfoundry_version/.tool-versions | grep '^scarb' | awk '{print $2}')
 
           echo "scarbVersion=$version" >> "$GITHUB_OUTPUT"
       - name: Setup Scarb

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup local action (with fixed version)
         uses: ./
         with:
-          starknet-foundry-version: 0.43.0
+          starknet-foundry-version: 0.44.0
 
       - name: Verify snforge version
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,7 +43,50 @@ jobs:
         with:
           scarb-version: ${{ steps.extractScarbVersion.outputs.scarbVersion }}
 
-      - name: Setup local action (with fixed version)
+      - name: Test local action
+        uses: ./
+        with:
+          starknet-foundry-version: latest
+
+      - name: Verify universal-sierra-compiler installation
+        run: universal-sierra-compiler --version
+
+      - name: Create new project
+        run: snforge init myproject
+
+      - name: Run tests in the project
+        run: snforge test
+        working-directory: myproject
+
+  test-action-with-tools-file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Create .tool-versions file"
+        shell: bash
+        run: echo -en 'scarb 2.5.0 \nstarknet-foundry 0.16.0' > .tool-versions
+
+      - name: "Setup Scarb using `.tool-versions` file"
+        uses: software-mansion/setup-scarb@v1
+
+      - name: "Setup foundry using `.tool-versions` file"
+        uses: ./
+
+      - run: snforge --version | grep "snforge 0.16.0"
+        shell: bash
+
+  test-action-with-fixed-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Setup Scarb using `.tool-versions` file"
+        uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: 2.9.4
+
+      - name: "Setup foundry using fixed version"
         uses: ./
         with:
           starknet-foundry-version: 0.44.0
@@ -60,35 +103,3 @@ jobs:
             echo "Version mismatch"
             exit 1
           fi
-
-
-      - name: Setup local action (with latest version)
-        uses: ./
-
-      - name: Verify universal-sierra-compiler installation
-        run: universal-sierra-compiler --version
-
-      - name: Create new project
-        run: snforge init myproject
-
-      - name: Run tests in the project
-        run: snforge test
-        working-directory: myproject
-
-  test-action-with-tools-file:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: "Create .tool-versions file"
-        shell: bash
-        run: echo -en 'scarb 2.5.0 \nstarknet-foundry 0.16.0' > .tool-versions
-
-      - name: "Setup Scarb using `.tool-versions` file"
-        uses: software-mansion/setup-scarb@v1
-
-      - name: "Setup foundry using `.tool-versions` file"
-        uses: ./
-
-      - run: snforge --version | grep "snforge 0.16.0"
-        shell: bash

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,10 +26,7 @@ jobs:
         run: npm run fmt:check
 
   test-action:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -62,10 +59,7 @@ jobs:
         working-directory: myproject
 
   test-action-with-tools-file:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,10 +59,7 @@ jobs:
         working-directory: myproject
 
   test-action-with-tools-file:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Test local action
         uses: ./
         with:
-          starknet-foundry-version: latest
+          starknet-foundry-version: 0.44.0
 
       - name: Verify universal-sierra-compiler installation
         run: universal-sierra-compiler --version

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     # At 16:00 on Wednesday
     - cron: "0 16 * * 3"
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           snfoundry_version=$(curl -s https://api.github.com/repos/foundry-rs/starknet-foundry/releases/latest | grep tarball_url | awk -F '/' '{print $8}' | tr -d '",')
-          version=$(curl -s https://raw.githubusercontent.com/foundry-rs/starknet-foundry/$snfoundry_version/.tool-versions | awk '{print $2}')
+          version=$(curl -s https://raw.githubusercontent.com/foundry-rs/starknet-foundry/$snfoundry_version/.tool-versions | grep '^scarb' | awk '{print $2}')
 
           echo "scarbVersion=$version" >> "$GITHUB_OUTPUT"
       - name: Setup Scarb

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,7 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: "Setup Scarb
+
+      - name: "Setup Scarb"
         uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: 2.9.4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,7 +91,6 @@ jobs:
         with:
           starknet-foundry-version: 0.44.0
 
-
       - name: Verify snforge version
         run: |
           EXPECTED="snforge 0.44.0"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,10 +43,16 @@ jobs:
         with:
           scarb-version: ${{ steps.extractScarbVersion.outputs.scarbVersion }}
 
-      - name: Test local action
+      - name: Test local action (with fixed version)
         uses: ./
         with:
-          starknet-foundry-version: latest
+          starknet-foundry-version: 0.44.0
+
+      - name: Check that snforge version is correct
+        run: snforge --version | grep "snforge 0.44.0"
+
+      - name: Test local action (with latest version)
+        uses: ./
 
       - name: Verify universal-sierra-compiler installation
         run: universal-sierra-compiler --version

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,6 @@ runs:
     - name: Set up Starknet Foundry
       shell: bash
       run: node $GITHUB_ACTION_PATH/dist/index.js
-      env:
-        INPUT_STARKNET-FOUNDRY-VERSION: ${{ inputs.starknet-foundry-version }}
-        INPUT_TOOL-VERSIONS: ${{ inputs.tool-versions }}
+      # env:
+      #   INPUT_STARKNET-FOUNDRY-VERSION: ${{ inputs.starknet-foundry-version }}
+      #   INPUT_TOOL-VERSIONS: ${{ inputs.tool-versions }}

--- a/action.yml
+++ b/action.yml
@@ -16,12 +16,15 @@ outputs:
     description: The prefix of installed Starknet Foundry
   starknet-foundry-version:
     description: The version of installed Starknet Foundry
-runs:
-  using: "composite"
-  steps:
-    - name: Set up Universal Sierra Compiler
-      uses: software-mansion/setup-universal-sierra-compiler@v1
+# runs:
+#   using: "composite"
+#   steps:
+#     - name: Set up Universal Sierra Compiler
+#       uses: software-mansion/setup-universal-sierra-compiler@v1
 
-    - name: Set up Starknet Foundry
-      shell: bash
-      run: node $GITHUB_ACTION_PATH/dist/index.js
+#     - name: Set up Starknet Foundry
+#       shell: bash
+#       run: node $GITHUB_ACTION_PATH/dist/index.js
+runs:
+  using: "node20"
+  main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -16,15 +16,15 @@ outputs:
     description: The prefix of installed Starknet Foundry
   starknet-foundry-version:
     description: The version of installed Starknet Foundry
-# runs:
-#   using: "composite"
-#   steps:
-#     - name: Set up Universal Sierra Compiler
-#       uses: software-mansion/setup-universal-sierra-compiler@v1
-
-#     - name: Set up Starknet Foundry
-#       shell: bash
-#       run: node $GITHUB_ACTION_PATH/dist/index.js
 runs:
-  using: "node20"
-  main: "dist/index.js"
+  using: "composite"
+  steps:
+    - name: Set up Universal Sierra Compiler
+      uses: software-mansion/setup-universal-sierra-compiler@v1
+
+    - name: Set up Starknet Foundry
+      shell: bash
+      run: node $GITHUB_ACTION_PATH/dist/index.js
+      env:
+        INPUT_STARKNET-FOUNDRY-VERSION: ${{ inputs.starknet-foundry-version }}
+        INPUT_TOOL-VERSIONS: ${{ inputs.tool-versions }}

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,6 @@ runs:
     - name: Set up Starknet Foundry
       shell: bash
       run: node $GITHUB_ACTION_PATH/dist/index.js
-      # env:
-      #   INPUT_STARKNET-FOUNDRY-VERSION: ${{ inputs.starknet-foundry-version }}
-      #   INPUT_TOOL-VERSIONS: ${{ inputs.tool-versions }}
+      env:
+        INPUT_STARKNET-FOUNDRY-VERSION: ${{ inputs.starknet-foundry-version }}
+        INPUT_TOOL-VERSIONS: ${{ inputs.tool-versions }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -29994,8 +29994,11 @@ async function findStarknetFoundryDir(extractedPath) {
 
 
 
+
 async function main() {
   try {
+    // await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
+
     const StarknetFoundryVersionInput = "${{ inputs.starknet-foundry-version }}";
     console.log(StarknetFoundryVersionInput);
     const toolVersionsPathInput = "${{ inputs.tool-versions }}";

--- a/dist/index.js
+++ b/dist/index.js
@@ -29996,8 +29996,8 @@ async function findStarknetFoundryDir(extractedPath) {
 
 async function main() {
   try {
-    console.log(core.getInput("starknet-foundry-version"));
-    console.log(core.getInput("tool-versions"));
+    console.log("core.getInput('starknet-foundry-version')",core.getInput("starknet-foundry-version"));
+    console.log("core.getInput('tool-versions')",core.getInput("tool-versions"));
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );

--- a/dist/index.js
+++ b/dist/index.js
@@ -29996,6 +29996,8 @@ async function findStarknetFoundryDir(extractedPath) {
 
 async function main() {
   try {
+    console.log(core.getInput("starknet-foundry-version"));
+    console.log(core.getInput("tool-versions"));
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );

--- a/dist/index.js
+++ b/dist/index.js
@@ -29819,8 +29819,7 @@ async function getFullVersionFromStarknetFoundry() {
   return match[1];
 }
 
-async function determineVersion(version, toolVersionsPath, repo) {
-  const versionFromInput = version?.trim();
+async function determineVersion(versionFromInput, toolVersionsPath, repo) {
   console.log("versionFromInput", versionFromInput)
   console.log("versionFromInput.length", versionFromInput.length)
   const versionFromFile = toolVersionsPath
@@ -29999,9 +29998,11 @@ async function main() {
   try {
     // await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
 
-    const StarknetFoundryVersionInput = "${{ inputs.starknet-foundry-version }}";
+    const StarknetFoundryVersionInput = core.getInput(
+      "starknet-foundry-version",
+    );
     console.log(StarknetFoundryVersionInput);
-    const toolVersionsPathInput = "${{ inputs.tool-versions }}";
+    const toolVersionsPathInput = core.getInput("tool-versions");
     console.log(toolVersionsPathInput);
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";

--- a/dist/index.js
+++ b/dist/index.js
@@ -29996,11 +29996,9 @@ async function findStarknetFoundryDir(extractedPath) {
 
 async function main() {
   try {
-    // const StarknetFoundryVersionInput = core.getInput(
-    //   "starknet-foundry-version",
-    // );
-    const StarknetFoundryVersionInput =
-      "${{ inputs.starknet-foundry-version }}";
+    const StarknetFoundryVersionInput = core.getInput(
+      "starknet-foundry-version",
+    );
 
     const toolVersionsPathInput = core.getInput("tool-versions");
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29996,9 +29996,10 @@ async function findStarknetFoundryDir(extractedPath) {
 
 async function main() {
   try {
-    const StarknetFoundryVersionInput = core.getInput(
-      "starknet-foundry-version",
-    );
+    // const StarknetFoundryVersionInput = core.getInput(
+    //   "starknet-foundry-version",
+    // );
+    const StarknetFoundryVersionInput = "${{ inputs.starknet-foundry-version }}";
 
     const toolVersionsPathInput = core.getInput("tool-versions");
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29819,14 +29819,18 @@ async function getFullVersionFromStarknetFoundry() {
   return match[1];
 }
 
-async function determineVersion(versionFromInput, toolVersionsPath, repo) {
+async function determineVersion(
+  versionFromInput,
+  toolVersionsPath,
+  repo,
+) {
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();
 
   if (versionFromInput && toolVersionsPath) {
     throw new Error(
-      "`starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
+      "`starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously",
     );
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29820,40 +29820,26 @@ async function getFullVersionFromStarknetFoundry() {
 }
 
 async function determineVersion(version, toolVersionsPath, repo) {
-  version = version?.trim();
+  const versionFromInput = version?.trim();
+  const versionFromFile = toolVersionsPath
+    ? await getVersionFromToolVersionsFile(toolVersionsPath)
+    : await getVersionFromToolVersionsFile();
 
-  if (version && toolVersionsPath) {
+  if (fromInput && toolVersionsPath) {
     throw new Error(
-      "the `starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously",
+      "The `starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
     );
   }
 
-  if (toolVersionsPath) {
-    let toolVersion = await getVersionFromToolVersionsFile(toolVersionsPath);
-
-    if (!toolVersion) {
-      throw new Error(
-        `failed to read Starknet Foundry version from: ${toolVersionsPath}`,
-      );
-    }
-    version = toolVersion;
-  }
-
-  if (!version) {
-    let toolVersion = await getVersionFromToolVersionsFile();
-    version = toolVersion ?? "latest";
-  }
+  version = versionFromInput || versionFromFile || "latest";
 
   if (version === "latest") {
     version = await fetchLatestTag(repo);
   }
 
-  if (version.startsWith("v")) {
-    version = version.substring(1);
-  }
-  console.log("VERSION: ",version);
-  return version;
+  return version.startsWith("v") ? version.slice(1) : version;
 }
+
 
 function fetchLatestTag(repo) {
   // Note: Asking GitHub API for latest release information is the simplest solution here, but has one major drawback:

--- a/dist/index.js
+++ b/dist/index.js
@@ -29851,7 +29851,7 @@ async function determineVersion(version, toolVersionsPath, repo) {
   if (version.startsWith("v")) {
     version = version.substring(1);
   }
-
+  console.log("VERSION: ",version);
   return version;
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29832,7 +29832,7 @@ async function determineVersion(versionFromInput, toolVersionsPath, repo) {
     );
   }
 
-  version = versionFromInput || versionFromFile || "latest";
+  let version = versionFromInput || versionFromFile || "latest";
 
   if (version === "latest") {
     version = await fetchLatestTag(repo);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29996,7 +29996,7 @@ async function findStarknetFoundryDir(extractedPath) {
 
 async function main() {
   try {
-    // await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
+    await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
 
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",

--- a/dist/index.js
+++ b/dist/index.js
@@ -29819,22 +29819,30 @@ async function getFullVersionFromStarknetFoundry() {
   return match[1];
 }
 
-async function determineVersion(
-  versionFromInput,
-  toolVersionsPath,
-  repo,
-) {
-  const versionFromFile = toolVersionsPath
-    ? await getVersionFromToolVersionsFile(toolVersionsPath)
-    : await getVersionFromToolVersionsFile();
+async function determineVersion(version, toolVersionsPath, repo) {
+  version = version?.trim();
 
-  if (versionFromInput && toolVersionsPath) {
+  if (version && toolVersionsPath) {
     throw new Error(
       "`starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously",
     );
   }
 
-  let version = versionFromInput || versionFromFile || "latest";
+  if (toolVersionsPath) {
+    const toolVersion = await getVersionFromToolVersionsFile(toolVersionsPath);
+
+    if (!toolVersion) {
+      throw new Error(
+        `failed to read Starknet Foundry version from: ${toolVersionsPath}`,
+      );
+    }
+    version = toolVersion;
+  }
+
+  if (!version) {
+    const toolVersion = await getVersionFromToolVersionsFile();
+    version = toolVersion ?? "latest";
+  }
 
   if (version === "latest") {
     version = await fetchLatestTag(repo);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29999,7 +29999,8 @@ async function main() {
     // const StarknetFoundryVersionInput = core.getInput(
     //   "starknet-foundry-version",
     // );
-    const StarknetFoundryVersionInput = "${{ inputs.starknet-foundry-version }}";
+    const StarknetFoundryVersionInput =
+      "${{ inputs.starknet-foundry-version }}";
 
     const toolVersionsPathInput = core.getInput("tool-versions");
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29996,14 +29996,10 @@ async function findStarknetFoundryDir(extractedPath) {
 
 async function main() {
   try {
-    console.log("core.getInput('starknet-foundry-version')",core.getInput("starknet-foundry-version"));
-    console.log("core.getInput('tool-versions')",core.getInput("tool-versions"));
-    const StarknetFoundryVersionInput = core.getInput(
-      "starknet-foundry-version",
-    );
-    console.log("StarknetFoundryVersionInput", StarknetFoundryVersionInput)
-
-    const toolVersionsPathInput = core.getInput("tool-versions");
+    const StarknetFoundryVersionInput = "${{ inputs.starknet-foundry-version }}";
+    console.log(StarknetFoundryVersionInput);
+    const toolVersionsPathInput = "${{ inputs.tool-versions }}";
+    console.log(toolVersionsPathInput);
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";
     const StarknetFoundryVersion = await determineVersion(

--- a/dist/index.js
+++ b/dist/index.js
@@ -29822,6 +29822,7 @@ async function getFullVersionFromStarknetFoundry() {
 async function determineVersion(version, toolVersionsPath, repo) {
   const versionFromInput = version?.trim();
   console.log("versionFromInput", versionFromInput)
+  console.log("versionFromInput.length", versionFromInput.length)
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();

--- a/dist/index.js
+++ b/dist/index.js
@@ -29820,8 +29820,6 @@ async function getFullVersionFromStarknetFoundry() {
 }
 
 async function determineVersion(versionFromInput, toolVersionsPath, repo) {
-  console.log("versionFromInput", versionFromInput)
-  console.log("versionFromInput.length", versionFromInput.length)
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();
@@ -29997,6 +29995,7 @@ async function main() {
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
+    
     const toolVersionsPathInput = core.getInput("tool-versions");
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";

--- a/dist/index.js
+++ b/dist/index.js
@@ -29825,7 +29825,7 @@ async function determineVersion(version, toolVersionsPath, repo) {
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();
 
-  if (fromInput && toolVersionsPath) {
+  if (versionFromInput && toolVersionsPath) {
     throw new Error(
       "The `starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
     );

--- a/dist/index.js
+++ b/dist/index.js
@@ -29821,6 +29821,7 @@ async function getFullVersionFromStarknetFoundry() {
 
 async function determineVersion(version, toolVersionsPath, repo) {
   const versionFromInput = version?.trim();
+  console.log("versionFromInput")
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();

--- a/dist/index.js
+++ b/dist/index.js
@@ -29828,7 +29828,7 @@ async function determineVersion(versionFromInput, toolVersionsPath, repo) {
 
   if (versionFromInput && toolVersionsPath) {
     throw new Error(
-      "The `starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
+      "`starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
     );
   }
 
@@ -29840,7 +29840,6 @@ async function determineVersion(versionFromInput, toolVersionsPath, repo) {
 
   return version.startsWith("v") ? version.slice(1) : version;
 }
-
 
 function fetchLatestTag(repo) {
   // Note: Asking GitHub API for latest release information is the simplest solution here, but has one major drawback:
@@ -29993,17 +29992,12 @@ async function findStarknetFoundryDir(extractedPath) {
 
 
 
-
 async function main() {
   try {
-    await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
-
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
-    console.log(StarknetFoundryVersionInput);
     const toolVersionsPathInput = core.getInput("tool-versions");
-    console.log(toolVersionsPathInput);
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";
     const StarknetFoundryVersion = await determineVersion(

--- a/dist/index.js
+++ b/dist/index.js
@@ -29995,7 +29995,7 @@ async function main() {
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
-    
+    console.log("StarknetFoundryVersionInput", StarknetFoundryVersionInput)
     const toolVersionsPathInput = core.getInput("tool-versions");
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";

--- a/dist/index.js
+++ b/dist/index.js
@@ -29821,7 +29821,7 @@ async function getFullVersionFromStarknetFoundry() {
 
 async function determineVersion(version, toolVersionsPath, repo) {
   const versionFromInput = version?.trim();
-  console.log("versionFromInput")
+  console.log("versionFromInput", versionFromInput)
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();

--- a/dist/index.js
+++ b/dist/index.js
@@ -29999,6 +29999,7 @@ async function main() {
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
+    console.log("StarknetFoundryVersionInput", StarknetFoundryVersionInput)
 
     const toolVersionsPathInput = core.getInput("tool-versions");
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29995,7 +29995,7 @@ async function main() {
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
-    console.log("StarknetFoundryVersionInput", StarknetFoundryVersionInput)
+
     const toolVersionsPathInput = core.getInput("tool-versions");
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,18 +11,13 @@ import { getOsTriplet } from "./platform";
 import path from "path";
 import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
-import * as exec from "@actions/exec";
 
 export default async function main() {
   try {
-    await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
-
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
-    console.log(StarknetFoundryVersionInput);
     const toolVersionsPathInput = core.getInput("tool-versions");
-    console.log(toolVersionsPathInput);
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";
     const StarknetFoundryVersion = await determineVersion(

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,7 +17,7 @@ export default async function main() {
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
-    
+    console.log("StarknetFoundryVersionInput", StarknetFoundryVersionInput)
     const toolVersionsPathInput = core.getInput("tool-versions");
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,6 +17,7 @@ export default async function main() {
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
+    console.log("StarknetFoundryVersionInput", StarknetFoundryVersionInput)
 
     const toolVersionsPathInput = core.getInput("tool-versions");
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,9 +17,11 @@ export default async function main() {
   try {
     // await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
 
-    const StarknetFoundryVersionInput = "${{ inputs.starknet-foundry-version }}";
+    const StarknetFoundryVersionInput = core.getInput(
+      "starknet-foundry-version",
+    );
     console.log(StarknetFoundryVersionInput);
-    const toolVersionsPathInput = "${{ inputs.tool-versions }}";
+    const toolVersionsPathInput = core.getInput("tool-versions");
     console.log(toolVersionsPathInput);
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,7 +17,7 @@ export default async function main() {
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
-    console.log("StarknetFoundryVersionInput", StarknetFoundryVersionInput)
+
     const toolVersionsPathInput = core.getInput("tool-versions");
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,11 +14,9 @@ import * as tc from "@actions/tool-cache";
 
 export default async function main() {
   try {
-    // const StarknetFoundryVersionInput = core.getInput(
-    //   "starknet-foundry-version",
-    // );
-    const StarknetFoundryVersionInput =
-      "${{ inputs.starknet-foundry-version }}";
+    const StarknetFoundryVersionInput = core.getInput(
+      "starknet-foundry-version",
+    );
 
     const toolVersionsPathInput = core.getInput("tool-versions");
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,9 +14,11 @@ import * as tc from "@actions/tool-cache";
 
 export default async function main() {
   try {
-    const StarknetFoundryVersionInput = core.getInput(
-      "starknet-foundry-version",
-    );
+    // const StarknetFoundryVersionInput = core.getInput(
+    //   "starknet-foundry-version",
+    // );
+    const StarknetFoundryVersionInput =
+      "${{ inputs.starknet-foundry-version }}";
 
     const toolVersionsPathInput = core.getInput("tool-versions");
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,7 @@ import * as exec from "@actions/exec";
 
 export default async function main() {
   try {
-    // await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
+    await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
 
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,8 +14,8 @@ import * as tc from "@actions/tool-cache";
 
 export default async function main() {
   try {
-    console.log(core.getInput("starknet-foundry-version"));
-    console.log(core.getInput("tool-versions"));
+    console.log("core.getInput('starknet-foundry-version')",core.getInput("starknet-foundry-version"));
+    console.log("core.getInput('tool-versions')",core.getInput("tool-versions"));
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,6 +17,7 @@ export default async function main() {
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );
+    
     const toolVersionsPathInput = core.getInput("tool-versions");
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,6 +14,8 @@ import * as tc from "@actions/tool-cache";
 
 export default async function main() {
   try {
+    console.log(core.getInput("starknet-foundry-version"));
+    console.log(core.getInput("tool-versions"));
     const StarknetFoundryVersionInput = core.getInput(
       "starknet-foundry-version",
     );

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,9 +11,12 @@ import { getOsTriplet } from "./platform";
 import path from "path";
 import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
+import * as exec from "@actions/exec";
 
 export default async function main() {
   try {
+    // await exec.exec("gh", ["run", "software-mansion/setup-universal-sierra-compiler@v1"]);
+
     const StarknetFoundryVersionInput = "${{ inputs.starknet-foundry-version }}";
     console.log(StarknetFoundryVersionInput);
     const toolVersionsPathInput = "${{ inputs.tool-versions }}";

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,14 +14,10 @@ import * as tc from "@actions/tool-cache";
 
 export default async function main() {
   try {
-    console.log("core.getInput('starknet-foundry-version')",core.getInput("starknet-foundry-version"));
-    console.log("core.getInput('tool-versions')",core.getInput("tool-versions"));
-    const StarknetFoundryVersionInput = core.getInput(
-      "starknet-foundry-version",
-    );
-    console.log("StarknetFoundryVersionInput", StarknetFoundryVersionInput)
-
-    const toolVersionsPathInput = core.getInput("tool-versions");
+    const StarknetFoundryVersionInput = "${{ inputs.starknet-foundry-version }}";
+    console.log(StarknetFoundryVersionInput);
+    const toolVersionsPathInput = "${{ inputs.tool-versions }}";
+    console.log(toolVersionsPathInput);
 
     const StarknetFoundryRepo = "foundry-rs/starknet-foundry";
     const StarknetFoundryVersion = await determineVersion(

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -14,8 +14,7 @@ export async function getFullVersionFromStarknetFoundry() {
   return match[1];
 }
 
-export async function determineVersion(version, toolVersionsPath, repo) {
-  const versionFromInput = version?.trim();
+export async function determineVersion(versionFromInput, toolVersionsPath, repo) {
   console.log("versionFromInput", versionFromInput)
   console.log("versionFromInput.length", versionFromInput.length)
   const versionFromFile = toolVersionsPath

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -16,6 +16,7 @@ export async function getFullVersionFromStarknetFoundry() {
 
 export async function determineVersion(version, toolVersionsPath, repo) {
   const versionFromInput = version?.trim();
+  console.log("versionFromInput")
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -14,22 +14,30 @@ export async function getFullVersionFromStarknetFoundry() {
   return match[1];
 }
 
-export async function determineVersion(
-  versionFromInput,
-  toolVersionsPath,
-  repo,
-) {
-  const versionFromFile = toolVersionsPath
-    ? await getVersionFromToolVersionsFile(toolVersionsPath)
-    : await getVersionFromToolVersionsFile();
+export async function determineVersion(version, toolVersionsPath, repo) {
+  version = version?.trim();
 
-  if (versionFromInput && toolVersionsPath) {
+  if (version && toolVersionsPath) {
     throw new Error(
       "`starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously",
     );
   }
 
-  let version = versionFromInput || versionFromFile || "latest";
+  if (toolVersionsPath) {
+    const toolVersion = await getVersionFromToolVersionsFile(toolVersionsPath);
+
+    if (!toolVersion) {
+      throw new Error(
+        `failed to read Starknet Foundry version from: ${toolVersionsPath}`,
+      );
+    }
+    version = toolVersion;
+  }
+
+  if (!version) {
+    const toolVersion = await getVersionFromToolVersionsFile();
+    version = toolVersion ?? "latest";
+  }
 
   if (version === "latest") {
     version = await fetchLatestTag(repo);

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -17,6 +17,7 @@ export async function getFullVersionFromStarknetFoundry() {
 export async function determineVersion(version, toolVersionsPath, repo) {
   const versionFromInput = version?.trim();
   console.log("versionFromInput", versionFromInput)
+  console.log("versionFromInput.length", versionFromInput.length)
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -16,7 +16,7 @@ export async function getFullVersionFromStarknetFoundry() {
 
 export async function determineVersion(version, toolVersionsPath, repo) {
   const versionFromInput = version?.trim();
-  console.log("versionFromInput")
+  console.log("versionFromInput", versionFromInput)
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -20,7 +20,7 @@ export async function determineVersion(version, toolVersionsPath, repo) {
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();
 
-  if (fromInput && toolVersionsPath) {
+  if (versionFromInput && toolVersionsPath) {
     throw new Error(
       "The `starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
     );

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -15,40 +15,26 @@ export async function getFullVersionFromStarknetFoundry() {
 }
 
 export async function determineVersion(version, toolVersionsPath, repo) {
-  version = version?.trim();
+  const versionFromInput = version?.trim();
+  const versionFromFile = toolVersionsPath
+    ? await getVersionFromToolVersionsFile(toolVersionsPath)
+    : await getVersionFromToolVersionsFile();
 
-  if (version && toolVersionsPath) {
+  if (fromInput && toolVersionsPath) {
     throw new Error(
-      "the `starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously",
+      "The `starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
     );
   }
 
-  if (toolVersionsPath) {
-    let toolVersion = await getVersionFromToolVersionsFile(toolVersionsPath);
-
-    if (!toolVersion) {
-      throw new Error(
-        `failed to read Starknet Foundry version from: ${toolVersionsPath}`,
-      );
-    }
-    version = toolVersion;
-  }
-
-  if (!version) {
-    let toolVersion = await getVersionFromToolVersionsFile();
-    version = toolVersion ?? "latest";
-  }
+  version = versionFromInput || versionFromFile || "latest";
 
   if (version === "latest") {
     version = await fetchLatestTag(repo);
   }
 
-  if (version.startsWith("v")) {
-    version = version.substring(1);
-  }
-  console.log("VERSION: ",version);
-  return version;
+  return version.startsWith("v") ? version.slice(1) : version;
 }
+
 
 function fetchLatestTag(repo) {
   // Note: Asking GitHub API for latest release information is the simplest solution here, but has one major drawback:

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -14,14 +14,18 @@ export async function getFullVersionFromStarknetFoundry() {
   return match[1];
 }
 
-export async function determineVersion(versionFromInput, toolVersionsPath, repo) {
+export async function determineVersion(
+  versionFromInput,
+  toolVersionsPath,
+  repo,
+) {
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();
 
   if (versionFromInput && toolVersionsPath) {
     throw new Error(
-      "`starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
+      "`starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously",
     );
   }
 

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -23,7 +23,7 @@ export async function determineVersion(versionFromInput, toolVersionsPath, repo)
 
   if (versionFromInput && toolVersionsPath) {
     throw new Error(
-      "The `starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
+      "`starknet-foundry-version` and `tool-versions` inputs cannot be used simultaneously"
     );
   }
 
@@ -35,7 +35,6 @@ export async function determineVersion(versionFromInput, toolVersionsPath, repo)
 
   return version.startsWith("v") ? version.slice(1) : version;
 }
-
 
 function fetchLatestTag(repo) {
   // Note: Asking GitHub API for latest release information is the simplest solution here, but has one major drawback:

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -46,7 +46,7 @@ export async function determineVersion(version, toolVersionsPath, repo) {
   if (version.startsWith("v")) {
     version = version.substring(1);
   }
-  console.log(version);
+  console.log("VERSION: ",version);
   return version;
 }
 

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -27,7 +27,7 @@ export async function determineVersion(versionFromInput, toolVersionsPath, repo)
     );
   }
 
-  version = versionFromInput || versionFromFile || "latest";
+  let version = versionFromInput || versionFromFile || "latest";
 
   if (version === "latest") {
     version = await fetchLatestTag(repo);

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -15,8 +15,6 @@ export async function getFullVersionFromStarknetFoundry() {
 }
 
 export async function determineVersion(versionFromInput, toolVersionsPath, repo) {
-  console.log("versionFromInput", versionFromInput)
-  console.log("versionFromInput.length", versionFromInput.length)
   const versionFromFile = toolVersionsPath
     ? await getVersionFromToolVersionsFile(toolVersionsPath)
     : await getVersionFromToolVersionsFile();

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -46,7 +46,7 @@ export async function determineVersion(version, toolVersionsPath, repo) {
   if (version.startsWith("v")) {
     version = version.substring(1);
   }
-
+  console.log(version);
   return version;
 }
 


### PR DESCRIPTION
Closes #31

Fix handling of `starknet-foundry-version` and `tool-versions` inputs - they now correctly determine the version to use.